### PR TITLE
Add more vscode workspace settings and recommended extensions

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "printWidth": 90
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,14 @@
+{
+	// See http://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		"esbenp.prettier-vscode",
+		"dbaeumer.vscode-eslint"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,8 @@
     "*.js": "javascriptreact"
   },
   "search.exclude": {
-    "**/node_modules": true
+    "**/node_modules": true,
+    "src/static": true
   },
   "javascript.preferences.importModuleSpecifier": "non-relative",
   "prettier.printWidth": 90,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,16 @@
 {
+  "editor.tabSize": 2,
+  "editor.formatOnSave": false,
+  // Enable/disable default JavaScript formatter (For Prettier)
+  "javascript.format.enable": false,
+  "prettier.eslintIntegration": true,
+  "files.associations": {
+    "*.js": "javascriptreact"
+  },
+  "search.exclude": {
+    "**/node_modules": true
+  },
+  "javascript.preferences.importModuleSpecifier": "non-relative",
+  "prettier.printWidth": 90,
   "javascript.implicitProjectConfig.experimentalDecorators": true
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -5,6 +5,6 @@
   },
   "exclude": [
     "node_modules",
-    "build"
+    "src/static"
   ]
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./src",
+    "experimentalDecorators": true
+  },
+  "exclude": [
+    "node_modules",
+    "build"
+  ]
+}


### PR DESCRIPTION
According the boilerplate.

This settings add recommended extensions to project folder: prettier and eslint.

With properly configured prettier plugin, user can format his code according eslint rules, it's really nice feature.

This settings also includes `search.exclude` option to make search faster in VSCode.

Option `javascript.preferences.importModuleSpecifier` configures auto-import behavior to add full path to imported module (from `./src` folder, of course) instead relative path from current file.

`jsconfig.json` file also configures project to correctly open it in VSCode and get comfortable workflow with working import suggestions and experimental decorators support.